### PR TITLE
불필요한 eval() 제거

### DIFF
--- a/modules/epay/plugins/iniescrow/libs/INIXml.php
+++ b/modules/epay/plugins/iniescrow/libs/INIXml.php
@@ -3411,24 +3411,9 @@ class XML
 			// Check whether more than one argument was given.
 			if ( func_num_args() > 1 )
 			{
-				// Read all arguments.
 				$arguments = func_get_args();
-				
-				// Create a new string for the inserting command.
-				$command = "\$message = sprintf(\$message, ";
-				
-				// Run through the array of arguments.
-				for ( $i = 1; $i < sizeof($arguments); $i++ )
-				{
-					// Add the number of the argument to the command.
-					$command .= "\$arguments[".$i."], ";
-				}
-				
-				// Replace the last separator.
-				$command = eregi_replace(", $", ");", $command);
-				
-				// Execute the command.
-				eval($command);
+				array_shift($arguments);
+				$message = vsprintf($message, $arguments);
 			}
 		
       // Display the error message.

--- a/modules/epay/plugins/inipay5/libs/INIXml.php
+++ b/modules/epay/plugins/inipay5/libs/INIXml.php
@@ -3411,24 +3411,9 @@ class XML
 			// Check whether more than one argument was given.
 			if ( func_num_args() > 1 )
 			{
-				// Read all arguments.
 				$arguments = func_get_args();
-				
-				// Create a new string for the inserting command.
-				$command = "\$message = sprintf(\$message, ";
-				
-				// Run through the array of arguments.
-				for ( $i = 1; $i < sizeof($arguments); $i++ )
-				{
-					// Add the number of the argument to the command.
-					$command .= "\$arguments[".$i."], ";
-				}
-				
-				// Replace the last separator.
-				$command = eregi_replace(", $", ");", $command);
-				
-				// Execute the command.
-				eval($command);
+				array_shift($arguments);
+				$message = vsprintf($message, $arguments);
 			}
 		
       // Display the error message.

--- a/modules/inipaystandard/libs/INIXml.php
+++ b/modules/inipaystandard/libs/INIXml.php
@@ -3444,25 +3444,9 @@ class XML
 			// Check whether more than one argument was given.
 			if ( func_num_args() > 1 )
 			{
-				// Read all arguments.
 				$arguments = func_get_args();
-				
-				// Create a new string for the inserting command.
-				$command = "\$message = sprintf(\$message, ";
-				
-				// Run through the array of arguments.
-				for ( $i = 1; $i < sizeof($arguments); $i++ )
-				{
-					// Add the number of the argument to the command.
-					$command .= "\$arguments[".$i."], ";
-				}
-				
-				// Replace the last separator.
-				//$command = eregi_replace(", $", ");", $command);
-				$command = preg_replace("/, $/i", ");", $command);
-				
-				// Execute the command.
-				eval($command);
+				array_shift($arguments);
+				$message = vsprintf($message, $arguments);
 			}
 		
       // Display the error message.

--- a/modules/ncart/ncart.view.php
+++ b/modules/ncart/ncart.view.php
@@ -79,8 +79,16 @@ class ncartView extends ncart
 			{
 				$node_route = $cate->node_route . $cate->node_id;
 				$stages = explode('.', $node_route);
-				$code_str = '$category_tree["' . implode('"]["', $stages) . '"] = array();';
-				eval($code_str);
+				$reference_tree = &$category_tree;
+				foreach($stages as $stage)
+				{
+				    if(!isset($reference_tree[$stage]))
+				    {
+				        $reference_tree[$stage] = array();
+				    }
+				    $reference_tree = &$reference_tree[$stage];
+				}
+				unset($reference_tree);
 				$category_index[$cate->node_id] = $cate;
 			}
 		}

--- a/modules/nproduct/nproduct.admin.view.php
+++ b/modules/nproduct/nproduct.admin.view.php
@@ -165,7 +165,7 @@ class nproductAdminView extends nproduct
 				unset($args);
 				$category_data->list[] = $output->data;
 			}
-			eval("\$category_data->depth{$count} = $node_id;");
+			$category_data->{'depth' . $count} = $node_id;
 			$count += 1;
 		}
 		Context::set('category_data', $category_data);

--- a/modules/nproduct/nproduct.category.php
+++ b/modules/nproduct/nproduct.category.php
@@ -50,8 +50,16 @@ class nproductCategory
 			{
 				$node_route = $cate->node_route . $cate->node_id;
 				$stages = explode('.', $node_route);
-				$code_str = '$category_tree["' . implode('"]["', $stages) . '"] = array();';
-				eval($code_str);
+				$reference_tree = &$category_tree;
+				foreach($stages as $stage)
+				{
+				    if(!isset($reference_tree[$stage]))
+				    {
+				        $reference_tree[$stage] = array();
+				    }
+				    $reference_tree = &$reference_tree[$stage];
+				}
+				unset($reference_tree);
 				$category_index[$cate->node_id] = $cate;
 			}
 		}

--- a/modules/nproduct/nproduct.view.php
+++ b/modules/nproduct/nproduct.view.php
@@ -88,8 +88,16 @@ class nproductView extends nproduct
 			{
 				$node_route = $cate->node_route . $cate->node_id;
 				$stages = explode('.', $node_route);
-				$code_str = '$category_tree["' . implode('"]["', $stages) . '"] = array();';
-				eval($code_str);
+				$reference_tree = &$category_tree;
+				foreach($stages as $stage)
+				{
+				    if(!isset($reference_tree[$stage]))
+				    {
+				        $reference_tree[$stage] = array();
+				    }
+				    $reference_tree = &$reference_tree[$stage];
+				}
+				unset($reference_tree);
 				$category_index[$cate->node_id] = $cate;
 			}
 		}

--- a/widgets/category_menu/category_menu.class.php
+++ b/widgets/category_menu/category_menu.class.php
@@ -40,8 +40,16 @@ class category_menu extends WidgetHandler
 			{
 				$node_route = $cate->node_route . $cate->node_id;
 				$stages = explode('.', $node_route);
-				$code_str = '$category_tree["' . implode('"]["', $stages) . '"] = array();';
-				eval($code_str);
+				$reference_tree = &$category_tree;
+				foreach($stages as $stage)
+				{
+				    if(!isset($reference_tree[$stage]))
+				    {
+				        $reference_tree[$stage] = array();
+				    }
+				    $reference_tree = &$reference_tree[$stage];
+				}
+				unset($reference_tree);
 				$module_info = $oModuleModel->getModuleInfoByModuleSrl($cate->module_srl);
 				if($module_info->mid)
 				{


### PR DESCRIPTION
불필요하게 eval() 함수를 사용하지 않도록 합니다.

PHP 총 9군데 중 8군데를 고쳤으나, modules/cympusadmin/cympusadmin.class.php에서 사용하는 구간은 쉽게 대체할 수 없어서 그대로 두었습니다.

원래 코드와 똑같이 작동하는지 테스트가 필요합니다.
