### PR TITLE
제품페이지에서 구매 옵션을 선택할 때 선택된 목록의 가격에 +가 붙는 문제 수정

### DIFF
--- a/modules/nproduct/tpl/skin.js/itemdetail.js
+++ b/modules/nproduct/tpl/skin.js/itemdetail.js
@@ -70,7 +70,7 @@ jQuery(function($) {
 			jQuery('span.number_format' + option_srl).html(number_format(ret_obj.price));
 		});
 		$.exec_json('nproduct.getPriceNumber', {'price': g_discounted_price + (price)}, function(ret_obj){
-			jQuery('td.title' + option_srl).html(title + '(' + '+' + number_format(ret_obj.price) + ')');
+			jQuery('td.title' + option_srl).html(title + ' (' + number_format(ret_obj.price) + ')');
 		});
 
 		printTotalPrice();


### PR DESCRIPTION
셀렉트박스에서는 기본 가격에 플러스되는 가격을 표시해줘야 하기 때문에 + 혹은 - 표시가 되어야 하지만
이미 선택된 옵션 목록은 플러스되거나 마이너스된 가격이 표시가 되기 때문에 +표시가 필요 없음.
+를 제외하고 괄호 시작 전에 스페이스 한칸을 주었음.