### PR TITLE
라이믹스에서 주소 검색 사용 불가능한 문제 수정

### DIFF
--- a/modules/ncart/ncart.view.php
+++ b/modules/ncart/ncart.view.php
@@ -387,7 +387,11 @@ class ncartView extends ncart
 		Context::set('epay_form', $epay_form);
 		unset($args);
 
-		Context::addJsFile('./modules/krzip/tpl/js/krzip_search.js');
+		if(defined('RX_VERSION')) {
+			Context::addJsFile('./modules/krzip/tpl/js/postcodify.js');
+		} else {
+			Context::addJsFile('./modules/krzip/tpl/js/krzip_search.js');
+		}
 		Context::set('soldout_process', $this->soldout_process);
 
 		$oNmileageModel = getModel('nmileage');


### PR DESCRIPTION
라이믹스에서 주소 검색을 사용할 수 없는 문제를 수정합니다.
코어 모듈의 파일을 직접 호출하지 않는 것이 가장 좋지만, 사용은 가능해야 하기 때문에 같은 방식의 대체 가능한 파일을 호출합니다.
https://xetown.com/questions/808171 를 반영했습니다.